### PR TITLE
Small change to enable building edex with ant from eclipse

### DIFF
--- a/edexOsgi/com.raytheon.uf.common.dataplugin.goesr.dmw/build.properties
+++ b/edexOsgi/com.raytheon.uf.common.dataplugin.goesr.dmw/build.properties
@@ -1,5 +1,4 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .,\
-               utility/
+               .


### PR DESCRIPTION
 - modified the build.properties file for the dmw plugin so it successfully builds the jar now